### PR TITLE
Fix issue #8 @types/react 

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,8 @@
     "allowSyntheticDefaultImports": true,
     "baseUrl": ".",
     "paths": {
-      "*": ["./typings/*"]
+      "*": ["./typings/*"],
+      "react": ["node_modules/@types/react"]
     }
   },
   "exclude": [


### PR DESCRIPTION
This fix the issue about @types/react

```
node_modules//node_modules//index.d.ts
(3535,13): error TS2403: Subsequent variable declarations must have the same type. Variable 'a' must be of type 'DetailedHTMLProps<AnchorHTMLAttributes, HTMLAnchorElement>', but here has type 'DetailedHTMLProps<AnchorHTMLAttributes, HTMLAnchorElement>'.
```
Fix #8