### PR TITLE
Fixes issue #14, the NotFound Route added an asyncComponent(), and th…

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -56,7 +56,7 @@ export const Routes = (props: Props) => {
       />
 
       {/* Finally, catch all unmatched routes */}
-      <Route component={asyncComponent(importNotFound)} />
+      <Route component={importNotFound} />
     </Switch>
   );
 };

--- a/src/pages/NotFound.js
+++ b/src/pages/NotFound.js
@@ -1,9 +1,11 @@
 import * as React from 'react';
 
-export const NotFound = () => {
+const NotFound = () => {
   return (
     <div className="NotFound">
       <h3>Sorry, page not found!</h3>
     </div>
   );
 };
+
+export default NotFound;


### PR DESCRIPTION
…e NotFound Page did not export default

Fixes #14 

I figured this was one of those quirky things that would be hard to track down.  My bug implied this was a problem with nesting routes, when in fact it had to do with the `NotFound` route being triggered.

@priley86 