### PR TITLE
fix vert nav active item

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -71,7 +71,9 @@ class App extends React.Component {
   render() {
     const { location } = this.props;
     const activeItem = this.menu.find(
-      item => location.pathname.indexOf(item.to) > -1
+      item =>
+        (item.to === '/' && location.pathname.indexOf('/ipsum') > -1) ||
+        location.pathname === item.to
     );
 
     const vertNavItems = this.menu.map(item => (


### PR DESCRIPTION
select active item based on route. Allows for `/ipsum` to be the default route and still selected when sub-nav is selected.

deployed example here:
https://patternfly-react-demo-app.firebaseapp.com

